### PR TITLE
Remove website from hyperlinks

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -5,8 +5,6 @@ class Location < ActiveRecord::Base
   belongs_to :organization, inverse_of: :locations, counter_cache: true
   belongs_to :federal_state, inverse_of: :locations
   has_many :offers, inverse_of: :location
-  has_many :hyperlinks, as: :linkable
-  has_many :websites, through: :hyperlinks
 
   # Validations
   validates :name, length: { maximum: 100 },

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -123,7 +123,6 @@ RailsAdmin.config do |config|
     field :longitude do
       read_only true
     end
-    field :websites
     field :completed
 
     show do

--- a/rails_best_practices_output.html
+++ b/rails_best_practices_output.html
@@ -57,9 +57,21 @@
       to see more useful Rails Best Practices.
     </p>
     <p>
-        No error found. Cool!
+        Found 1 warnings.
     </p>
     <table>
+          <tr>
+              <td>
+                <input type="checkbox" class="error-type" id="UseQueryAttributeReview" value="UseQueryAttributeReview"
+                />&nbsp;<label for="UseQueryAttributeReview">Use Query Attribute</label>
+              </td>
+          </tr>
+        <tr>
+          <td colspan="3">
+            <button id="show-all">Check all</button>
+            <button id="show-none">Uncheck all</button>
+          </td>
+        </tr>
     </table>
     <table class="result">
       <thead>
@@ -70,6 +82,15 @@
         </tr>
       </thead>
       <tbody>
+          <tr class="UseQueryAttributeReview">
+            <td class='filename'>
+                app/views/offers/show.html.slim
+            </td>
+            <td class='line'>45</td>
+            <td class='message'>
+              <a href='http://rails-bestpractices.com/posts/56-use-query-attribute' target='_blank'>use query attribute (@offer.opening_specification?)</a>
+            </td>
+          </tr>
       </tbody>
     </table>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>

--- a/test/factories/locations.rb
+++ b/test/factories/locations.rb
@@ -24,13 +24,6 @@ FactoryGirl.define do
     organization
     federal_state { FederalState.select(:id).all.sample || FederalState.create(name: 'Berlin') }
 
-    ignore do
-      website_count { rand(0..3) }
-    end
-    after :create do |location, evaluator|
-      create_list :hyperlink, evaluator.website_count, linkable: location
-    end
-
     trait :fake_address do
       street { Faker::AddressDE.street_address }
       zip { (10_000..14_100).to_a.sample }

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -46,8 +46,6 @@ describe Location do
   describe '::Base' do
     describe 'associations' do
       it { subject.must have_many :offers }
-      it { subject.must have_many :hyperlinks }
-      it { subject.must have_many :websites }
       it { subject.must belong_to :organization }
       it { subject.must belong_to :federal_state }
     end


### PR DESCRIPTION
Wenn das deployed wird und mn direkt im Anschluss in der Konsole noch folgendes macht:

    Hyperlink.where(linkable_type: "Location").each do |hyperlink|
      hyperlink.destroy
    end

Reicht das oder ist noch mehr zu tun?