### PR TITLE
fix for #402 - add worker that regularly updates definitions (interval TBD)

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -80,7 +80,7 @@ class Offer < ActiveRecord::Base
   end
 
   # handled in observer before save
-  def generate_html
+  def generate_html!
     self.description_html = MarkdownRenderer.render description
     self.description_html = Definition.infuse description_html
     self.next_steps_html = MarkdownRenderer.render next_steps
@@ -88,6 +88,7 @@ class Offer < ActiveRecord::Base
       self.opening_specification_html =
         MarkdownRenderer.render opening_specification
     end
+    true
   end
 
   # Get an array of websites, ordered as follows: (1) own non-pdf (2) own pdf

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -94,7 +94,7 @@ class Organization < ActiveRecord::Base
   end
 
   # handled in observer before save
-  def generate_html
+  def generate_html!
     self.description_html = MarkdownRenderer.render description
   end
 

--- a/app/observers/offer_observer.rb
+++ b/app/observers/offer_observer.rb
@@ -4,7 +4,7 @@ class OfferObserver < ActiveRecord::Observer
   end
 
   def before_save offer
-    offer.generate_html
+    offer.generate_html!
   end
 
   def before_create offer

--- a/app/observers/organization_observer.rb
+++ b/app/observers/organization_observer.rb
@@ -1,6 +1,6 @@
 class OrganizationObserver < ActiveRecord::Observer
   def before_save orga
-    orga.generate_html
+    orga.generate_html!
   end
 
   def before_create orga

--- a/app/workers/regenerate_html_worker.rb
+++ b/app/workers/regenerate_html_worker.rb
@@ -1,0 +1,39 @@
+class RegenerateHtmlWorker
+  include Sidekiq::Worker
+  include Sidetiq::Schedulable
+
+  recurrence { daily.hour_of_day(0) }
+
+  def perform
+    Offer.approved.find_each do |offer|
+      old = {
+        description_html: offer.description_html,
+        next_steps_html: offer.next_steps_html,
+        opening_specification_html: offer.opening_specification_html
+      }
+
+      offer.generate_html!
+
+      actual_changes = changes(offer, old)
+      offer.update_columns actual_changes if actual_changes
+    end
+  end
+
+  private
+
+  def changes object, old
+    news = {}
+    old.each do |field, old_string|
+      new_string = object.send(field)
+      next if new_string == old_string
+      news[field] = new_string
+    end
+
+    if news.keys.count > 0
+      news[:updated_at] = Time.zone.now
+      return news
+    else
+      return false
+    end
+  end
+end

--- a/test/workers/regenerate_html_worker_test.rb
+++ b/test/workers/regenerate_html_worker_test.rb
@@ -1,0 +1,48 @@
+require_relative '../test_helper'
+
+class RegenerateHtmlWorkerTest < ActiveSupport::TestCase
+  # extend ActiveSupport::TestCase to get fixtures
+  let(:worker) { RegenerateHtmlWorker.new }
+
+  describe '#changes' do
+    it 'should register changes in an object' do
+      old = { foo: 'unchanged', bar: 'unchanged' }
+      obj = OpenStruct.new foo: 'unchanged', bar: 'changed'
+
+      result = worker.send(:changes, obj, old)
+
+      result[:foo].must_be :nil?
+      result[:bar].must_equal 'changed'
+      result[:updated_at].wont_be :nil?
+      result.keys.count.must_equal 2
+    end
+
+    it 'should return false when there are no changes' do
+      old = { foo: 'unchanged', bar: 'unchanged' }
+      obj = OpenStruct.new foo: 'unchanged', bar: 'unchanged'
+
+      result = worker.send(:changes, obj, old)
+      result.must_equal false
+    end
+  end
+
+  describe 'perform' do
+    before do
+      # Run worker initially so everything in database is updated to the
+      # most recent state
+      worker.perform
+    end
+
+    it 'should send an update when there has been a changed offer' do
+      FactoryGirl.create :definition, key: offers(:basic).description
+
+      Offer.any_instance.expects(:update_columns)
+      worker.perform
+    end
+
+    it 'wont send an update when there has been no changed offer' do
+      Offer.any_instance.expects(:update_columns).never
+      worker.perform
+    end
+  end
+end


### PR DESCRIPTION
Also in Issue #402 heißt es, dass sich definitions immer noch nicht aktualisieren würden. Tun sie natürlich auch nicht selbstständig, das Offer muss erst nochmal gespeichert werden. Irgend ein obskurer rails bug sorgt aber scheinbar auch dafür, dass wenn in der Speicherung nicht sowieso was an bspw. der description getan wurde, es trotzdem nicht neu generiert wird.

Daher gibt es nun einen Worker der immer mal durchläuft und alle approved offers auf den neusten Stand bringt was generiertes Markdown (inkl. Definitions) angeht.

Läuft erstmal täglich um 0 Uhr. Intervall kann man leicht anpassen. Auch überlegenswert wäre ne Lösung, wo die Researcher einen Button klicken können, um das manuell auslösen zu können. Dann wird es tatsächlich nur gemacht, wenn auch Dinge verändert wurden.

Aber es klappt auch erstmal so.