### PR TITLE
Feature/761 target blank emails

### DIFF
--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -109,5 +109,5 @@ about supported directives.
 # = require modules/safari_fixes
 # = require modules/cookie_warning
 # = require modules/faq
-# = require modules/shariff_addional
+# = require modules/shariff_additonal
 # = require modules/refocus

--- a/app/assets/javascripts/modules/shariff_additonal.coffee
+++ b/app/assets/javascripts/modules/shariff_additonal.coffee
@@ -12,5 +12,4 @@ shariffAdditional = ->
   , ->
     $buttons.addClass "shariff-button--expanded"
 
-$(document).on 'page:load', shariffAdditional
 $(document).ready shariffAdditional

--- a/app/assets/javascripts/modules/shariff_additonal.coffee
+++ b/app/assets/javascripts/modules/shariff_additonal.coffee
@@ -1,6 +1,8 @@
-shariffExpand = ->
+shariffAdditional = ->
 
   $buttons = $('.shariff-button')
+
+  $('.shariff').find('a[href^="mailto"]').attr('target', '_blank')
 
   $buttons.hover ->
 
@@ -10,5 +12,5 @@ shariffExpand = ->
   , ->
     $buttons.addClass "shariff-button--expanded"
 
-$(document).on 'page:load', shariffExpand
-$(document).ready shariffExpand
+$(document).on 'page:load', shariffAdditional
+$(document).ready shariffAdditional

--- a/app/helpers/email_obfuscation_helper.rb
+++ b/app/helpers/email_obfuscation_helper.rb
@@ -48,7 +48,7 @@ module EmailObfuscationHelper
               (c <= 'Z' ? 90 : 122) >= (c = c.charCodeAt(0) + 13) ? c : c - 26
         );});
         document.getElementById('secure-email-' + #{index}).innerHTML =
-          '<a href='+'ma'+'il'+'to:'+ string +'>#{linktext}</a>';
+          '<a href='+'ma'+'il'+'to:'+ string +' target="_blank">#{linktext}</a>';
       //]]></script>
     SCRIPT
       .html_safe

--- a/app/views/offers/show.html.slim
+++ b/app/views/offers/show.html.slim
@@ -106,7 +106,7 @@
   / mobile share buttons
   .shariff data={ lang: I18n.locale, \
                   services: '["mail", "whatsapp", "facebook", "twitter"]', \
-                  'mail-url' => 'mailto:',  }
+                  'mail-url' => 'mailto:' }
 
   / - content_for :view_specific_scripts do
   /   = javascript_include_tag "gmaps_search_results.js"

--- a/app/views/offers/show.html.slim
+++ b/app/views/offers/show.html.slim
@@ -106,7 +106,7 @@
   / mobile share buttons
   .shariff data={ lang: I18n.locale, \
                   services: '["mail", "whatsapp", "facebook", "twitter"]', \
-                  'mail-url' => 'mailto:' }
+                  'mail-url' => 'mailto:',  }
 
   / - content_for :view_specific_scripts do
   /   = javascript_include_tag "gmaps_search_results.js"


### PR DESCRIPTION
@KonstantinKo : Please check and refactor. Ziel war/ist es, dass E-Mail-Links in den Kontakten und der 'Teilen-Funktion' immer in einem neuen Tab aufgehen (wenn man Web-Clients wie Gmail verwendet).

Sprich mich auch gerne noch mal drauf an, gerade was shariff_additonal.coffee haben wir ja einen neuen Ansatz was den Style angeht, oder?