### PR TITLE
Change blog link to clarat plus link

### DIFF
--- a/app/views/layouts/partials/_footer.html.slim
+++ b/app/views/layouts/partials/_footer.html.slim
@@ -26,7 +26,7 @@ footer.footer-main
         nav.nav-site
           ul.nav-site__list
             li.nav-site__listitem
-              = link_to t('.blog'), 'http://blog.clarat.org/'
+              = link_to t('.plus'), 'http://plus.clarat.org/'
             li.nav-site__listitem.nav-site__listitem--facebook-refugees
               = link_to t('.facebook_refugees'), 'https://www.facebook.com/claratrefugees/'
             li.nav-site__listitem.nav-site__listitem--facebook-family

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -868,6 +868,7 @@ ar:
         twitter:
           anchor: تويتر
           href: https://twitter.com/claratpunktorg
+        plus: 
       modal:
         beta_modal:
           link: ارسل لنا ببساطة رسالة بريد إليكتروني

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1353,6 +1353,7 @@ de:
         twitter:
           anchor: Twitter
           href: https://twitter.com/claratpunktorg
+        plus: clarat plus
       modal:
         beta_modal:
           link: schreibe uns einfach eine Nachricht.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -924,6 +924,7 @@ en:
         twitter:
           anchor: Twitter
           href: https://twitter.com/claratpunktorg
+        plus: clarat plus
       modal:
         beta_modal:
           link: write us a message.

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -935,6 +935,7 @@ fa:
         twitter:
           anchor: توییتر
           href: https://twitter.com/claratpunktorg
+        plus: 
       modal:
         beta_modal:
           link: برای ما پیغام بنویسید

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -960,6 +960,7 @@ fr:
         twitter:
           anchor: Twitter
           href: https://twitter.com/claratpunktorg
+        plus: 
       modal:
         beta_modal:
           link: écris-nous tout simplement un message

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1004,6 +1004,7 @@ pl:
         twitter:
           anchor: Twitter
           href: https://twitter.com/claratpunktorg
+        plus: 
       modal:
         beta_modal:
           link: po prostu napisz do nas wiadomość

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -987,6 +987,7 @@ ru:
         twitter:
           anchor: Twitter
           href: https://twitter.com/claratpunktorg
+        plus: 
       modal:
         beta_modal:
           link: просто напиши нам E-Mail.

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -877,6 +877,7 @@ tr:
         twitter:
           anchor: Twitter
           href: https://twitter.com/claratpunktorg
+        plus: 
       modal:
         beta_modal:
           link: bize mesaj gönder.


### PR DESCRIPTION
Nur eine Verlinkung von clarat plus an der Stelle, wo der Blog-Link ist. In localeapp ist node angelegt und zumindest bei de und en was eingetragen. Zeitnahes Deployment wäre super für Birte