### PR TITLE
Sort order changed

### DIFF
--- a/app/objects/form/search_form.rb
+++ b/app/objects/form/search_form.rb
@@ -43,7 +43,7 @@ class SearchForm
   attribute :encounters, String,
             default: (Offer::ENCOUNTERS - %w(personal)).join(',')
   ### Sort Order
-  attribute :sort_order, String, default: :nearby
+  attribute :sort_order, String, default: :relevance
   enumerize :sort_order, in: [:nearby, :relevance]
   ### Section (world)
   attribute :section_identifier, String, default: :family


### PR DESCRIPTION
clarat-org/clarat#1253
'Beste Treffer' als default Sortierung bei den Suchergebnissen
